### PR TITLE
fix(dblinter/S001-rule):skip scan for schema named public

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
   rev: v4.3.0
   hooks:
   - id: check-yaml # Validates YAML files
+    exclude: 'tests/data/config_file_syntax_error\.yaml'
 - repo: local
   hooks:
   - id: isort
@@ -25,7 +26,7 @@ repos:
     stages: [commit]
     language: system
     types: [python]
-    entry: poetry run ruff .
+    entry: poetry run ruff check .
 
   - id: pylint
     name: pylint

--- a/dblinter/default_config.yaml
+++ b/dblinter/default_config.yaml
@@ -53,7 +53,7 @@ base:
       coef: 5
       resource_gain: Primary keys ensure no duplicates are present in the table.
       risk_impact: Duplicate rows possible, breaking data integrity. Replication failures, inefficient updates requiring full table scans. Severe performance degradation on large tables and logical replication issues.
-  - name: HowManyRedudantIndex
+  - name: HowManyRedundantIndex
     ruleid: B002
     enabled: True
     params:
@@ -77,9 +77,9 @@ base:
       desc: Count number of tables without index on foreign key.
       message: "{0} table without index on foreign key exceed the warning threshold: {1}%. Object list [{2}]"
       fixes:
-        - Create a index on foreign key
+        - Create an index on foreign key
       coef: 3
-      resource_gain: Foreign keys indexes improve JOIN performance and enable efficient cascade operations.
+      resource_gain: Foreign key indexes improve JOIN performance and enable efficient cascade operations.
       risk_impact: Extremely slow JOIN queries and cascade operations. DELETE/UPDATE on parent tables can lock child tables for extended periods, causing application timeouts and severe performance issues.
   - name: HowManyUnusedIndex
     ruleid: B004
@@ -216,8 +216,8 @@ table:
     ruleid: T010
     enabled: True
     context:
-      desc: A table, his column or indexes use reserved keywords.
-      message: "{0} {1}.{2}.{3}.{4} violate retricted keyword rule."
+      desc: A table, its columns or indexes use reserved keywords.
+      message: "{0} {1}.{2}.{3}.{4} violate restricted keyword rule."
       fixes:
         - Rename the object to use a non reserved keyword
       coef: 1
@@ -234,7 +234,7 @@ table:
       fixes:
         - Ask a DBA
       coef: 1
-      resource_gain: Adding appropriate indexes to high-seqscan tables will improve query performance and reduces I/O load, freeing resources for other queries.
+      resource_gain: Adding appropriate indexes to high-seqscan tables improves query performance and reduces I/O load, freeing resources for other queries.
       risk_impact: High sequential scan rates indicate missing indexes, causing severe performance issues. Full table scans consume excessive memory and I/O, potentially causing OOM errors and impacting all database users.
   - name: TableWithSensibleColumn
     ruleid: T012
@@ -246,13 +246,13 @@ table:
         - Install extension PostgreSQL Anonymizer, and create some masking rules on
         coef: 1
         resource_gain: Proper data classification and masking reduces compliance audit time. Enables safe data sharing for development and testing environments.
-        risk_impact: GDPR/CCPA compliance violations risk with fines. Unprotected PII exposure in logs, backups, and non-production environments. Severe reputational damage risk.
+        risk_impact: Risk of GDPR/CCPA compliance violations with fines. Unprotected PII exposure in logs, backups, and non-production environments. Severe reputational damage risk.
 schema:
   - name: SchemaWithDefaultRoleNotGranted
     ruleid: S001
     enabled: True
     context:
-      desc: The schema ha no default role. Means that futur table will not be granted through a role. So you will have to re-execute grants on it.
+      desc: The schema has no default role. Means that future tables will not be granted through a role. So you will have to re-execute grants on it.
       message: "No default role granted on schema {0}.{1}. It means that each time a table is created, you must grant it to roles."
       fixes:
         - "Add a default privilege=> ALTER DEFAULT PRIVILEGES IN SCHEMA <schema> for user <schema's owner>"
@@ -270,4 +270,3 @@ schema:
       coef: 2
       resource_gain: Environment-neutral naming simplifies refresh operations. Eliminates complex rename scripts.
       risk_impact: Complex and error-prone environment refresh procedures. Risk of broken references, failed migrations, and extended downtime during refresh operations. Potential data integrity issues.
-

--- a/dblinter/rules/C003/PasswordEncryptionIsMd5.py
+++ b/dblinter/rules/C003/PasswordEncryptionIsMd5.py
@@ -6,7 +6,7 @@ LOGGER = logging.getLogger("dblinter")
 
 
 def password_encryption_is_md5(
-    self, db: DatabaseConnection, param, context, sarif_document
+    self, db: DatabaseConnection, _param, context, sarif_document
 ):
     LOGGER.debug("password_encryption_is_md5")
     password_encryption = db.query(

--- a/dblinter/rules/S001/SchemaWithDefaultRoleNotGranted.py
+++ b/dblinter/rules/S001/SchemaWithDefaultRoleNotGranted.py
@@ -14,7 +14,7 @@ def schema_with_default_role_not_granted(
     )
 
     # Ignore the 'public' schema
-    if schema[0] == 'public':
+    if schema[0] == "public":
         LOGGER.debug("Skipping 'public' schema")
         return
 

--- a/dblinter/rules/S001/SchemaWithDefaultRoleNotGranted.py
+++ b/dblinter/rules/S001/SchemaWithDefaultRoleNotGranted.py
@@ -12,6 +12,12 @@ def schema_with_default_role_not_granted(
     LOGGER.debug(
         "schema_with_default_role_not_granted for %s in db %s", schema[0], db.database
     )
+
+    # Ignore the 'public' schema
+    if schema[0] == 'public':
+        LOGGER.debug("Skipping 'public' schema")
+        return
+
     SCHEMA_WITH_ROLE_NOT_GRANTED = f"""SELECT count(*)
     FROM pg_catalog.pg_default_acl d
     LEFT JOIN pg_catalog.pg_namespace n ON n.oid = d.defaclnamespace

--- a/dblinter/scan.py
+++ b/dblinter/scan.py
@@ -11,9 +11,8 @@ from rich import print as rprint
 from dblinter.configuration import Configuration
 from dblinter.configuration_model import ConfigurationModel
 from dblinter.database_connection import DatabaseConnection
-from dblinter.function_library import FunctionLibrary
+from dblinter.function_library import EXCLUDED_SCHEMAS_STR, FunctionLibrary
 from dblinter.sarif_document import SarifDocument
-from dblinter.function_library import EXCLUDED_SCHEMAS_STR
 
 DEFAULT_CONFIG_FILE_NAME = "default_config.yaml"
 PATH = "dblinter"


### PR DESCRIPTION
# PR Description

## Link to the initial request/ticket

- N/A (improvement initiative)

## What this PR Provides

- **S001 Rule Enhancement**: Ignore the `public` schema in `SchemaWithDefaultRoleNotGranted` rule
- **Code Quality Improvements**: Fix typos and grammar in configuration files
  - Correct `HowManyRedudantIndex` to `HowManyRedundantIndex`
  - Fix `retricted` to `restricted`
  - Improve consistency across configuration messages

## How to test

### Test the S001 rule fix

1. **Create a test database with public schema (no default privileges)**:
```sql
-- Connect to PostgreSQL
CREATE DATABASE test_s001;
\c test_s001

-- The public schema exists by default
-- No default privileges configured